### PR TITLE
9 add flow log skeleton

### DIFF
--- a/client/src/assets/mock_data.ts
+++ b/client/src/assets/mock_data.ts
@@ -14,71 +14,6 @@ export const listItems = [
     name: 'Test GPS location tracker turns on',
     link: ''
   }
-  /* {
-    id: 4,
-    name: 'Test interface updates on request',
-    link: '',
-  },
-  {
-    id: 1,
-    name: 'Test button activates backend and light',
-    link: '',
-  },
-  {
-    id: 2,
-    name: 'Test light switches',
-    link: '',
-  },
-  {
-    id: 3,
-    name: 'Test GPS location tracker turns on',
-    link: '',
-  },
-  {
-    id: 4,
-    name: 'Test interface updates on request',
-    link: '',
-  },
-  {
-    id: 1,
-    name: 'Test button activates backend and light',
-    link: '',
-  },
-  {
-    id: 2,
-    name: 'Test light switches',
-    link: '',
-  },
-  {
-    id: 3,
-    name: 'Test GPS location tracker turns on',
-    link: '',
-  },
-  {
-    id: 4,
-    name: 'Test interface updates on request',
-    link: '',
-  },
-  {
-    id: 1,
-    name: 'Test button activates backend and light',
-    link: '',
-  },
-  {
-    id: 2,
-    name: 'Test light switches',
-    link: '',
-  },
-  {
-    id: 3,
-    name: 'Test GPS location tracker turns on',
-    link: '',
-  },
-  {
-    id: 4,
-    name: 'Test interface updates on request',
-    link: '',
-  } */
 ]
 
 export const headerItems = [
@@ -100,14 +35,60 @@ export const headerItems = [
 ]
 
 export const logItems = [
-  'Device 1',
-  'Device 2',
-  'Device 3',
-  'Device 4',
-  'Device 5',
-  'Device 6',
-  'Device 7',
-  'Device 8',
-  'Device 9',
-  'Device 10'
+  {
+    id: 1,
+    name: 'Device 1',
+    log: [
+      '2021-07-01T00:00:00.000Z',
+      '2021-07-01T00:00:01.000Z',
+      '2021-07-01T00:00:02.000Z',
+      '2021-07-01T00:00:03.000Z',
+      '2021-07-01T00:00:04.000Z',
+      '2021-07-01T00:00:05.000Z',
+      '2021-07-01T00:00:06.000Z',
+      '2021-07-01T00:00:07.000Z',
+      '2021-07-01T00:00:08.000Z',
+      '2021-07-01T00:00:09.000Z',
+      '2021-07-01T00:00:10.000Z',
+      '2021-07-01T00:00:11.000Z',
+      '2021-07-01T00:00:12.000Z'
+    ]
+  },
+  {
+    id: 2,
+    name: 'Device 2',
+    log: ['2021-07-01T00:00:00.000Z']
+  },
+  {
+    id: 3,
+    name: 'Device 3',
+    log: [
+      '2021-07-01T00:00:00.000Z',
+      '2021-07-01T00:00:09.000Z',
+      '2021-07-01T00:00:10.000Z',
+      '2021-07-01T00:00:11.000Z'
+    ]
+  },
+  {
+    id: 4,
+    name: 'Device 4',
+    log: [
+      '2021-07-01T00:00:00.000Z',
+      '2021-07-01T00:00:01.000Z',
+      '2021-07-01T00:00:07.000Z',
+      '2021-07-01T00:00:08.000Z',
+      '2021-07-01T00:00:09.000Z'
+    ]
+  },
+  {
+    id: 5,
+    name: 'Device 5',
+    log: [
+      '2021-07-01T00:00:00.000Z',
+      '2021-07-01T00:00:01.000Z',
+      '2021-07-01T00:00:02.000Z',
+      '2021-07-01T00:00:03.000Z',
+      '2021-07-01T00:00:04.000Z'
+    ]
+  }
 ]

--- a/client/src/assets/mock_data.ts
+++ b/client/src/assets/mock_data.ts
@@ -98,3 +98,16 @@ export const headerItems = [
     link: 'api'
   }
 ]
+
+export const logItems = [
+  'Device 1',
+  'Device 2',
+  'Device 3',
+  'Device 4',
+  'Device 5',
+  'Device 6',
+  'Device 7',
+  'Device 8',
+  'Device 9',
+  'Device 10'
+]

--- a/client/src/components/FlowLog.vue
+++ b/client/src/components/FlowLog.vue
@@ -2,30 +2,51 @@
 defineProps<{
   show: boolean
 }>()
-import { logItems } from '@/assets/mock_data'
 
+import LogList from '@/components/LogList.vue'
+import { logItems } from '@/assets/mock_data'
+import { ref } from 'vue'
+
+const currentDevice = ref(0)
 </script>
 
-<template >
-  <section v-if="show" class="mt-4 w-ful flex gap-2">
-    <ul class="flex h-14 flex-grow gap-2 overflow-x-scroll">
-      <li
-        class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500"
-      >
-        All Devices
-      </li>
-      <li
-        key="item"
-        v-for="item in logItems"
-        class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500"
-      >
-        {{ item }}
-      </li>
-    </ul>
-    <a
-      href=""
-      class="ml-auto mr-4 h-fit flex-shrink-0 rounded-md bg-accent-400 px-4 py-1.5 shadow-md transition-colors duration-200 hover:bg-accent-500"
-      >Export log</a
-    >
-  </section>
+<template>
+  <div v-if="show">
+    <nav class="mt-4 flex gap-2">
+      <ul class="flex h-14 flex-grow gap-2 overflow-x-scroll">
+        <li
+          @click="currentDevice = 0"
+          :aria-expanded="currentDevice === 0"
+          class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500 aria-expanded:bg-accent-400"
+        >
+          All Devices
+        </li>
+        <li
+          :key="item.id"
+          v-for="item in logItems"
+          @click="currentDevice = item.id"
+          :aria-expanded="currentDevice === item.id"
+          class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500 aria-expanded:bg-accent-400"
+        >
+          {{ item.name }}
+        </li>
+      </ul>
+      <a
+        href=""
+        class="ml-auto mr-4 flex h-fit flex-shrink-0 gap-2 rounded-md bg-accent-400 px-4 py-1.5 shadow-md transition-colors duration-200 hover:bg-accent-500"
+        >Export log
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          class="fill-accent-800"
+          height="24"
+          viewBox="0 -960 960 960"
+        >
+          <path
+            d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58zM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160z"
+          /></svg
+      ></a>
+    </nav>
+    <log-list :device-id="currentDevice" />
+  </div>
 </template>

--- a/client/src/components/FlowLog.vue
+++ b/client/src/components/FlowLog.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+defineProps<{
+  show: boolean
+}>()
+import { logItems } from '@/assets/mock_data'
+
+</script>
+
+<template >
+  <section v-if="show" class="mt-4 w-ful flex gap-2">
+    <ul class="flex h-14 flex-grow gap-2 overflow-x-scroll">
+      <li
+        class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500"
+      >
+        All Devices
+      </li>
+      <li
+        key="item"
+        v-for="item in logItems"
+        class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500"
+      >
+        {{ item }}
+      </li>
+    </ul>
+    <a
+      href=""
+      class="ml-auto mr-4 h-fit flex-shrink-0 rounded-md bg-accent-400 px-4 py-1.5 shadow-md transition-colors duration-200 hover:bg-accent-500"
+      >Export log</a
+    >
+  </section>
+</template>

--- a/client/src/components/FlowLog.vue
+++ b/client/src/components/FlowLog.vue
@@ -17,6 +17,7 @@ const currentDevice = ref(0)
         <li
           @click="currentDevice = 0"
           :aria-expanded="currentDevice === 0"
+          tabindex="1"
           class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500 aria-expanded:bg-accent-400"
         >
           All Devices
@@ -26,6 +27,7 @@ const currentDevice = ref(0)
           v-for="item in logItems"
           @click="currentDevice = item.id"
           :aria-expanded="currentDevice === item.id"
+          tabindex="1"
           class="h-fit w-fit flex-shrink-0 rounded-md bg-white-100 px-4 py-1.5 shadow-md transition-colors duration-200 hover:cursor-pointer hover:bg-accent-500 aria-expanded:bg-accent-400"
         >
           {{ item.name }}
@@ -33,6 +35,7 @@ const currentDevice = ref(0)
       </ul>
       <a
         href=""
+        tabindex="1"
         class="ml-auto mr-4 flex h-fit flex-shrink-0 gap-2 rounded-md bg-accent-400 px-4 py-1.5 shadow-md transition-colors duration-200 hover:bg-accent-500"
         >Export log
         <svg

--- a/client/src/components/LogList.vue
+++ b/client/src/components/LogList.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+  deviceId: number
+}>()
+
+import { logItems } from '@/assets/mock_data'
+</script>
+<template>
+  <section class="mb-8 h-full max-h-[calc(100vh-14rem)] overflow-y-scroll">
+    <ul v-if="deviceId !== 0">
+      <li v-for="log in logItems.find((item) => item.id === deviceId)?.log" :key="log">
+        {{ log }}
+      </li>
+    </ul>
+    <ul v-else>
+      <li
+        :key="deviceLogItem"
+        v-for="deviceLogItem in logItems.flatMap((device) => device.log).sort()"
+      >
+        {{ deviceLogItem }}
+      </li>
+    </ul>
+  </section>
+</template>

--- a/client/src/components/PageHeader.vue
+++ b/client/src/components/PageHeader.vue
@@ -5,7 +5,7 @@ import { headerItems } from '@/assets/mock_data'
   <header class="fixed top-0 flex h-12 w-screen gap-40 bg-accent-800">
     <h1 class="ml-8 w-min text-2xl text-accent-400">liltest</h1>
     <ul class="ml-2 mr-auto flex flex-row gap-4">
-      <li v-for="item in headerItems" :key=item.id class="flex justify-center">
+      <li v-for="item in headerItems" :key="item.id" class="flex justify-center">
         <router-link
           :to="{ name: item.link }"
           tabindex="1"

--- a/client/src/components/PageHeader.vue
+++ b/client/src/components/PageHeader.vue
@@ -5,7 +5,7 @@ import { headerItems } from '@/assets/mock_data'
   <header class="fixed top-0 flex h-12 w-screen gap-40 bg-accent-800">
     <h1 class="ml-8 w-min text-2xl text-accent-400">liltest</h1>
     <ul class="ml-2 mr-auto flex flex-row gap-4">
-      <li v-for="item in headerItems" v-bind:key="item.id" class="flex justify-center">
+      <li v-for="item in headerItems" :key=item.id class="flex justify-center">
         <router-link
           :to="{ name: item.link }"
           tabindex="1"

--- a/client/src/components/PageNavigation.vue
+++ b/client/src/components/PageNavigation.vue
@@ -6,15 +6,15 @@ import { listItems } from '@/assets/mock_data'
   <nav id="header__rounded_corner" class="fixed left-0 top-12 h-screen w-64 bg-accent-800 pl-4">
     <h2 class="pl-4 text-lg text-white-100">Stored Flows</h2>
 
-    <ul class="relative flex max-h-[calc(100vh-9.5rem)] flex-col overflow-y-scroll py-4">
+    <ul class="relative gap-2 flex max-h-[calc(100vh-9.5rem)] flex-col overflow-y-scroll py-4">
       <li
         v-bind:key="item.id"
         v-for="item in listItems"
         :aria-expanded="item.id === $route.params.id"
-        class="text-md nav_item__rounded relative rounded-l-xl text-white-100 hover:cursor-pointer hover:bg-white-200 hover:text-accent-900 aria-expanded:bg-white-200 aria-expanded:text-accent-900"
+        class="z-10 hover:z-50 text-md nav_item__rounded relative rounded-l-xl text-white-100 hover:cursor-pointer hover:bg-white-200/80 hover:text-accent-900 aria-expanded:bg-white-200 aria-expanded:text-accent-900"
       >
         <router-link
-          :to="{ name: 'flow', params: { id: item.id } }"
+          :to="`/flow/${item.id}`"
           tabindex="2"
           class="line-clamp-1 max-w-56 text-ellipsis py-1.5 pl-4 pr-2 leading-10"
           >{{ item.name }}</router-link

--- a/client/src/components/PageNavigation.vue
+++ b/client/src/components/PageNavigation.vue
@@ -6,12 +6,12 @@ import { listItems } from '@/assets/mock_data'
   <nav id="header__rounded_corner" class="fixed left-0 top-12 h-screen w-64 bg-accent-800 pl-4">
     <h2 class="pl-4 text-lg text-white-100">Stored Flows</h2>
 
-    <ul class="relative gap-2 flex max-h-[calc(100vh-9.5rem)] flex-col overflow-y-scroll py-4">
+    <ul class="relative flex max-h-[calc(100vh-9.5rem)] flex-col gap-2 overflow-y-scroll py-4">
       <li
         v-bind:key="item.id"
         v-for="item in listItems"
         :aria-expanded="item.id === $route.params.id"
-        class="z-10 hover:z-50 text-md nav_item__rounded relative rounded-l-xl text-white-100 hover:cursor-pointer hover:bg-white-200/80 hover:text-accent-900 aria-expanded:bg-white-200 aria-expanded:text-accent-900"
+        class="text-md nav_item__rounded relative z-10 rounded-l-xl text-white-100 hover:z-50 hover:cursor-pointer hover:bg-white-200/80 hover:text-accent-900 hover:shadow-xl hover:transition-colors hover:duration-200 aria-expanded:bg-white-200 aria-expanded:text-accent-900 aria-expanded:duration-0"
       >
         <router-link
           :to="`/flow/${item.id}`"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,8 +8,7 @@ body {
   color: #001e1e;
 }
 
-/* top rounding when navigation item is hovered */
-.nav_item__rounded:hover:before,
+/* top rounding when navigation item is selected */
 .nav_item__rounded[aria-expanded='true']::before {
   content: '';
   position: absolute;
@@ -22,21 +21,7 @@ body {
   box-shadow: #fefefe 1rem 1rem 0 1rem;
 }
 
-/* both these selectors removes the radius to prevent overlap */
-.nav_item__rounded:hover + .nav_item__rounded[aria-expanded='true'] {
-  &::before {
-    display: none;
-  }
-}
-
-.nav_item__rounded[aria-expanded='true'] + .nav_item__rounded {
-  &::before {
-    display: none;
-  }
-}
-
-/* bottom rounding when navigation item is hovered */
-.nav_item__rounded:hover:after,
+/* bottom rounding when navigation item is selected */
 .nav_item__rounded[aria-expanded='true']::after {
   content: '';
   position: absolute;

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import LandingView from '@//views/LandingView.vue'
 import FlowView from '@/views/FlowView.vue'
-import LogView from '@/views/LogView.vue'
+import LogView from '@/components/FlowLog.vue'
 import DevicesView from '@/views/DevicesView.vue'
 import ApiView from '@/views/ApiView.vue'
 import NewDeviceView from '@/views/NewDeviceView.vue'
@@ -16,11 +16,11 @@ const routes = [
   {
     path: '/flow/:id',
     name: 'flow',
-    component: FlowView,
-    props: true
+    component: FlowView
   },
   {
     path: '/flow/:id/log',
+    name: 'log',
     component: LogView,
     props: true
   },

--- a/client/src/views/FlowView.vue
+++ b/client/src/views/FlowView.vue
@@ -11,7 +11,7 @@ const displayLog = ref(false)
     <h1>{{ listItems.find((item) => item.id === $route.params.id)?.name }}</h1>
 
     <flow-log :show="displayLog" />
-    <button @click="displayLog = !displayLog" class="fixed bottom-6 right-4">
+    <button @click="displayLog = !displayLog" class="fixed bottom-6 right-4" tabindex="1">
       Display log: {{ displayLog }}
     </button>
   </main>

--- a/client/src/views/FlowView.vue
+++ b/client/src/views/FlowView.vue
@@ -1,20 +1,18 @@
 <script setup lang="ts">
-
 import { listItems } from '@/assets/mock_data'
-import LogView from '../components/FlowLog.vue';
-import { ref } from 'vue';
+import FlowLog from '@/components/FlowLog.vue'
+import { ref } from 'vue'
 
-const displayLog = ref(false);
-
+const displayLog = ref(false)
 </script>
 
 <template>
   <main class="flex flex-col">
-     <h1>{{ listItems.find((item) => item.id === $route.params.id)?.name }} </h1>
+    <h1>{{ listItems.find((item) => item.id === $route.params.id)?.name }}</h1>
 
-
-    <LogView :show=displayLog />
-    <button @click="displayLog = !displayLog" class="absolute bottom-4">Test</button>
-
+    <flow-log :show="displayLog" />
+    <button @click="displayLog = !displayLog" class="fixed bottom-6 right-4">
+      Display log: {{ displayLog }}
+    </button>
   </main>
 </template>

--- a/client/src/views/FlowView.vue
+++ b/client/src/views/FlowView.vue
@@ -1,24 +1,20 @@
 <script setup lang="ts">
-import { reactive, watch } from 'vue'
-import { useRoute } from 'vue-router'
 
 import { listItems } from '@/assets/mock_data'
+import LogView from '../components/FlowLog.vue';
+import { ref } from 'vue';
 
-const route = useRoute()
-const item = listItems.find((item) => item.id === route.params.id)
-const state = reactive({ id: route.params.id, name: item!.name })
+const displayLog = ref(false);
 
-watch(
-  () => route.params.id,
-  (newId) => {
-    state.id = newId
-    state.name = listItems.find((item) => item.id === newId)!.name
-  }
-)
 </script>
 
 <template>
-  <main class="flex w-screen">
-    <h1>{{ state.name }}</h1>
+  <main class="flex flex-col">
+     <h1>{{ listItems.find((item) => item.id === $route.params.id)?.name }} </h1>
+
+
+    <LogView :show=displayLog />
+    <button @click="displayLog = !displayLog" class="absolute bottom-4">Test</button>
+
   </main>
 </template>

--- a/client/src/views/LogView.vue
+++ b/client/src/views/LogView.vue
@@ -1,3 +1,0 @@
-<template>
-  <h1>Log</h1>
-</template>


### PR DESCRIPTION
Adds the framework to build the log view for a flow, tabs and temporary logs are displayed using mock data.

This pull request also fixes some prior routing issues, updating to follow Vue best practises; removing warnings.

In addition this prettifies the navigation hover effect somewhat. 