### PR TITLE
44 configure backend formatting script

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.isort]
-profile = "black"  # Use black's formatting style
-line_length = 79    # Ensure the line length matches black's
+profile = "black"
+line_length = 79
 
 [tool.black]
 line-length = 79

--- a/server/scripts/check.sh
+++ b/server/scripts/check.sh
@@ -1,11 +1,11 @@
 echo "Checking server code format"
-cd ..
+cd "$(dirname "$0")/.."
 echo "isort"
 isort --check-only .
 echo -e "\nflake8"
 flake8 .
 echo -e "\nblack"
-black --check
+black --check .
 echo -e "\nmypy"
 mypy .
 

--- a/server/scripts/format.sh
+++ b/server/scripts/format.sh
@@ -1,5 +1,5 @@
 echo "Formatting server code"
-cd ..
+cd "$(dirname "$0")/.."
 isort .
 black .
 echo "Done formatting code :)"

--- a/server/server_comm/data_manager/apps.py
+++ b/server/server_comm/data_manager/apps.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 
-
 class DataManagerConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "data_manager"

--- a/server/server_comm/data_manager/apps.py
+++ b/server/server_comm/data_manager/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
+
 class DataManagerConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "data_manager"

--- a/server/server_comm/data_manager/urls.py
+++ b/server/server_comm/data_manager/urls.py
@@ -1,4 +1,3 @@
-# data_manager/urls.py
 from django.urls import path
 
 from .views import (

--- a/server/server_comm/data_manager/views.py
+++ b/server/server_comm/data_manager/views.py
@@ -1,4 +1,3 @@
-# data_manager/views.py
 from rest_framework import generics
 
 from .models import Category, Device, Edge, Flow, Node


### PR DESCRIPTION
- Changed the way the script moves out to the server folder, because somehow that made a difference in whether it used the .toml file for the formatting configurations when you don't run the script from the scripts folder (ie. running "bash scripts/format.sh" from server results in the wrong formatting when "cd .." is used instead of the current navigation)
- Deleted some comments that were left over from previous PR