### PR TITLE
Add test for connection between android device and bluetooth device

### DIFF
--- a/server/adb_ble_connection/adb_ble_conn_utils.py
+++ b/server/adb_ble_connection/adb_ble_conn_utils.py
@@ -1,0 +1,74 @@
+import os
+import subprocess
+
+
+def run_adb_test(
+    android_device_id,
+    target_uuid,
+    extra_address,
+    test_script,
+    test_xml,
+    result_file,
+):
+    if os.path.exists(result_file):
+        os.remove(result_file)
+
+    command = [
+        test_script,
+        "-d",
+        android_device_id,
+        "-E",
+        "TARGET_UUID",
+        target_uuid,
+        "-E",
+        "EXTRA_ADDRESS",
+        extra_address,
+        test_xml,
+    ]
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True)
+        return result.stdout, result.stderr
+    except Exception as e:
+        return None, str(e)
+
+
+def check_test_results(result_file):
+    if not os.path.exists(result_file):
+        return None, "Result file not found"
+
+    try:
+        with open(result_file, 'r') as file:
+            content = file.read()
+
+            if "FAIL" in content:
+                return False, "Test failed"
+            else:
+                return True, "Test passed"
+    except Exception as e:
+        return None, str(e)
+
+
+if __name__ == "__main__":
+    test_bat = 'test.bat'  # For linux/Mac use '\.test.sh'
+    test_xml = 'test_connect.xml'
+    result_file = os.path.join('test_connect_result.txt')
+
+    android_device_id = "R5CW51LN1PD"
+    target_uuid = "0000180D-0000-1000-8000-00805f9b34fb" #HR service UUID
+    extra_address = "F1:CD:70:40:99:AA"  # MAC address of bluetooth device
+
+    stdout, stderr = run_adb_test(
+        android_device_id,
+        target_uuid,
+        extra_address,
+        test_bat,
+        test_xml,
+        result_file,
+    )
+    print(stdout)
+    print(stderr)
+
+    result, message = check_test_results(result_file)
+    print(result)
+    print(message)

--- a/server/adb_ble_connection/adb_ble_conn_utils.py
+++ b/server/adb_ble_connection/adb_ble_conn_utils.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     result_file = os.path.join('test_connect_result.txt')
 
     android_device_id = "R5CW51LN1PD"
-    target_uuid = "0000180D-0000-1000-8000-00805f9b34fb" #HR service UUID
+    target_uuid = "0000180D-0000-1000-8000-00805f9b34fb"  # HR service UUID
     extra_address = "F1:CD:70:40:99:AA"  # MAC address of bluetooth device
 
     stdout, stderr = run_adb_test(

--- a/server/adb_ble_connection/test.bat
+++ b/server/adb_ble_connection/test.bat
@@ -1,0 +1,218 @@
+@echo off
+rem Copyright (c) 2014-2019, Nordic Semiconductor
+rem All rights reserved.
+rem 
+rem Redistribution and use in source and binary forms, with or without
+rem modification, are permitted provided that the following conditions are met:
+rem 
+rem * Redistributions of source code must retain the above copyright notice, this
+rem   list of conditions and the following disclaimer.
+rem 
+rem * Redistributions in binary form must reproduce the above copyright notice,
+rem   this list of conditions and the following disclaimer in the documentation
+rem   and/or other materials provided with the distribution.
+rem 
+rem * Neither the name of nRF Toolbox nor the names of its
+rem   contributors may be used to endorse or promote products derived from
+rem   this software without specific prior written permission.
+rem 
+rem THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+rem AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+rem IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+rem DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+rem FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+rem DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+rem SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+rem CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+rem OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+rem OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+rem 
+rem Description:
+rem ------------
+rem The script allows to run automated tests using Android phone.
+rem The script may be run on Windows.
+rem
+rem Requirements:
+rem -------------
+rem 1. Android device with Android version 4.3+ connected by USB cable with the PC
+rem 2. The path to Android platform-tools directory must be added to %PATH% environment variable, f.e: C:\Program Files\Android ADT Bundle\sdk\platform-tools
+rem 3. nRF Connect (2.1.0+) application installed on the Android device
+rem 4. "Developer options" and "USB debugging" must be enabled on the Android device
+rem
+rem Usage:
+rem ------
+rem 1. Open command line
+rem 2. Type "test -?" and press ENTER
+rem
+rem Android Debug Bridge (adb):
+rem ---------------------------
+rem You must have Android platform tools installed on the computer or the files: adb.exe, AdbWinApi.dll copied to the same directory.
+rem Go to http://developer.android.com/sdk/index.html for more information how to install it on the computer.
+rem You do not need the whole ADT Bundle (with Eclipse or Android Studio). Only SDK Tools with Platform Tools are required.
+rem 
+rem ==================================================================================
+setlocal
+set PROGRAM=%~0
+set DEVICE=
+set S_DEVICE=
+set EXTRAS=
+
+rem ==================================================================================
+rem Check ADB
+
+call adb devices > nul 2>&1
+if errorLevel 1 (
+	call :info
+	echo Error: adb is not recognized as an external command. 
+	echo        Add [Android Bundle path]/sdk/platform-tools to %%PATH%%
+	goto error
+)
+
+rem ==================================================================================
+rem Check help
+if "%~1"=="" goto usage
+if "%~1"=="-?" goto usage
+if "%~1"=="/?" goto usage
+
+rem ==================================================================================
+rem Read the target device id
+if /I "%~1"=="-d" set TARGET_DEVICE_SET=1
+if defined TARGET_DEVICE_SET (
+	if not "%~1"=="" (
+		set DEVICE=%~2
+		set S_DEVICE=-s %~2
+		shift
+		shift
+	) else goto usage
+)
+
+rem Read optional extra parameters
+:read_extras
+if /I "%~1"=="-e" set EXTRAS_SET=1
+if defined EXTRAS_SET (
+	if not "%~1"=="" (
+		set EXTRAS=%EXTRAS% -e %~2 "%~3"
+		shift
+		shift
+		shift
+	) else goto usage
+)
+rem More extras?
+if /I "%~1"=="-e" goto :read_extras
+
+rem ==================================================================================
+rem Write intro
+call :info
+
+rem Read file name and fully qualified path name to the XML file
+if "%~1"=="" (
+	echo Error: Test script file name not specified.
+	goto error
+)
+set XML_FILE=%~nx1
+set RESULT_FILE=%~n1_result.txt
+set XML_PATH="%~f1"
+if not exist %XML_PATH% (
+	echo Error: The given test script file has not been found.
+	goto error
+)
+
+rem ==================================================================================
+if "%DEVICE%"=="" (
+	rem Check if there is only one device connected
+	for /f "delims=" %%a in ('call adb devices ^| findstr "device unauthorized emulator" ^| find /c /v "devices"') do (
+		if "%%a"=="0" (
+			echo Error: No device connected.
+			goto error
+		)
+		if not "%%a"=="1" (
+			echo Error: More than one device connected. 
+			echo        Specify the device serial number using -d option:
+			call adb devices
+			goto usage_only
+			goto error
+		)
+	)
+) else (
+	rem Check if specified device is connected
+	for /f "delims=" %%a in ('call adb devices ^| find /c "%DEVICE%"') do (
+		if "%%a"=="0" (
+			echo Error: Device with serial number "%DEVICE%" is not connected.
+			call adb devices
+			goto error
+		)
+	)
+)
+
+rem ==================================================================================
+rem Remove old result file (if exists)
+echo|set /p=Removing old result file...
+call adb shell rm "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/%RESULT_FILE%" > nul 2>&1
+echo OK
+
+rem Copy selected file onto the device
+echo|set /p=Copying "%XML_FILE%" to /sdcard/Android/data/no.nordicsemi.android.mcp/files/Test...
+call adb %S_DEVICE% push %XML_PATH% "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/%XML_FILE%" > nul 2>&1
+if errorLevel 1 (
+	echo FAIL
+	echo Error: Device not found.
+	goto error
+) else echo OK
+
+rem Start test service on the device
+echo|set /p=Starting test service...
+rem Note: For phones running Android system older than Oreo, use "am startservice" below.
+call adb %S_DEVICE% shell am start-foreground-service -a no.nordicsemi.android.action.START_TEST^
+ %EXTRAS% -e no.nordicsemi.android.test.extra.EXTRA_FILE_PATH "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/%XML_FILE%" > nul 2>&1
+if errorLevel 1 (
+	echo FAIL
+	echo Error: Required application not installed.
+	goto error
+) else (
+	echo OK
+	echo Test started...OK
+)
+
+rem Try to obtain the result. Wait 10 seconds before every try.
+echo|set /p=Waiting for the result...
+:read_result
+rem Wait 10 sec, this IP address is reserved and does not exist
+ping 192.0.2.3 -n 1 -w 10000 > nul
+call adb %S_DEVICE% pull "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/%RESULT_FILE%" "%RESULT_FILE%" > nul 2>&1
+if errorLevel 1 goto :read_result
+
+echo OK
+echo Result saved in "%RESULT_FILE%".
+
+goto exit
+
+rem ==================================================================================
+:info
+echo =================================================
+echo Nordic Semiconductor Automated Tests batch script
+echo =================================================
+goto eof
+
+rem ==================================================================================
+:usage
+call :info
+:usage_only
+echo Usage:
+echo %PROGRAM% [-D device_id] [-E key value] script.xml
+echo Info:
+echo device_id - Call: "adb devices" to get list of serial numbers
+echo key=value - You may pass 0+ parameters to the Test Service, f.e. 
+echo             -E EXTRA_ADDRESS "AA:BB:CC:DD:EE:FF" -E SOMETHING "important" 
+echo             and use them in the script.xml file as f.e. 
+echo             ..address="${EXTRA_ADDRESS}"...
+goto exit
+
+rem ==================================================================================
+:error
+set errorLevel=1
+
+rem ==================================================================================
+:exit
+endlocal
+
+:eof

--- a/server/adb_ble_connection/test.sh
+++ b/server/adb_ble_connection/test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Copyright (c) 2024, Nordic Semiconductor
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of nRF Toolbox nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Description:
+# ------------
+# The script allows to run automated tests using Android phone.
+# The script may be run on Unix / Mac / Linux.
+#
+# Requirements:
+# -------------
+# 1. Android device with Android version 4.3+ connected by USB cable with the PC
+# 2. The path to Android platform-tools directory must be added to %PATH% environment variable
+# 3. nRF Connect (2.1.0+) application installed on the Android device
+# 4. "Developer options" and "USB debugging" must be enabled on the Android device
+#
+# Usage:
+# ------
+# 1. Open console
+# 2. Type "./test.sh --help" and press ENTER
+#
+# Android Debug Bridge (adb):
+# ---------------------------
+# You must have Android platform tools installed on the computer.
+# Go to http://developer.android.com/sdk/index.html for more information how to install it on the computer.
+# You do not need the whole ADT Bundle (with Eclipse or Android Studio). Only SDK Tools with Platform Tools are required.
+
+# Set variables
+PROGRAM="$0"
+DEVICE=""
+S_DEVICE=""
+EXTRAS=""
+
+# Check ADB
+if ! command -v adb > /dev/null 2>&1; then
+    echo "Error: adb is not recognized as an external command."
+    echo "       Add [Android Bundle path]/sdk/platform-tools to \$PATH"
+    exit 1
+fi
+
+# Check help
+if [ -z "$1" ] || [ "$1" = "--help" ]; then
+    echo "Usage: $PROGRAM [-D device_id] [-E key value] script.xml"
+    echo "Info:"
+    echo "device_id - Call: \"adb devices\" to get a list of serial numbers"
+    echo "key value - You may pass 0+ parameters to the Test Service, e.g.,"
+    echo "            -E EXTRA_ADDRESS \"AA:BB:CC:DD:EE:FF\" -E SOMETHING \"important\""
+    echo "            and use them in the script.xml file as e.g.:"
+    echo "            ..address=\"\${EXTRA_ADDRESS}\"..."
+    exit 1
+fi
+
+# Read target device id
+if [ "$1" = "-d" ]; then
+    TARGET_DEVICE_SET=1
+    shift
+    DEVICE="$1"
+    S_DEVICE="-s $1"
+    shift
+fi
+
+# Read optional extra parameters
+while [ "$1" = "-e" ]; do
+    EXTRAS_SET=1
+    shift
+    EXTRAS="$EXTRAS -e $1 \"$2\""
+    shift 2
+done
+
+# Write intro
+echo "================================================="
+echo "Nordic Semiconductor Automated Tests shell script"
+echo "================================================="
+
+# Read file name and fully qualified path name to the XML file
+if [ -z "$1" ]; then
+    echo "Error: Test script file name not specified."
+    exit 1
+fi
+
+XML_FILE=$(basename "$1")
+RESULT_FILE="${1%.*}_result.txt"
+XML_PATH=$(realpath "$1")
+
+if [ ! -e "$XML_PATH" ]; then
+    echo "Error: The given test script file has not been found."
+    exit 1
+fi
+
+# Check if there is only one device connected
+if [ -z "$DEVICE" ]; then
+    DEVICE_COUNT=$(adb devices | grep -v "devices" | grep -c "device\|unauthorized\|emulator")
+    if [ "$DEVICE_COUNT" -eq 0 ]; then
+        echo "Error: No device connected."
+        exit 1
+    elif [ "$DEVICE_COUNT" -gt 1 ]; then
+        echo "Error: More than one device connected."
+        echo "       Specify the device serial number using -D option:"
+        adb devices
+        exit 1
+    fi
+else
+    # Check if specified device is connected
+    if ! adb devices | grep -q "$DEVICE"; then
+        echo "Error: Device with serial number \"$DEVICE\" is not connected."
+        adb devices
+        exit 1
+    fi
+fi
+
+# Remove old result file (if exists)
+echo -n "Removing old result file..."
+adb $S_DEVICE shell rm "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/$RESULT_FILE" > /dev/null 2>&1
+echo "OK"
+
+# Copy selected file onto the device
+echo -n "Copying \"$XML_FILE\" to /sdcard/Android/data/no.nordicsemi.android.mcp/files/Test..."
+adb $S_DEVICE push "$XML_PATH" "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/$XML_FILE" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL"
+    echo "Error: Device not found."
+    exit 1
+else
+    echo "OK"
+fi
+
+# Start test service on the device
+echo -n "Starting test service..."
+adb $S_DEVICE shell am start-foreground-service -a no.nordicsemi.android.action.START_TEST $EXTRAS -e no.nordicsemi.android.test.extra.EXTRA_FILE_PATH "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/$XML_FILE" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL"
+    echo "Error: Required application not installed."
+    exit 1
+else
+    echo "OK"
+    echo "Test started...OK"
+fi
+
+# Try to obtain the result. Wait 10 seconds before every try.
+echo -n "Waiting for the result..."
+while true; do
+    # Wait 10 sec, this IP address is reserved and does not exist
+    sleep 10
+    adb $S_DEVICE pull "/sdcard/Android/data/no.nordicsemi.android.mcp/files/Test/$RESULT_FILE" "$RESULT_FILE" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        break
+    fi
+done
+echo "OK"
+echo "Result saved in \"$RESULT_FILE\"."
+exit 0

--- a/server/adb_ble_connection/test_connect.xml
+++ b/server/adb_ble_connection/test_connect.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-suite description="Bluetooth connection between Android device and nRF Kit">
+
+    <set name="TARGET_UUID" value="${TARGET_UUID}" />
+
+    <target id="devkit" name="Dev Kit" address="${EXTRA_ADDRESS}" />
+
+    <test id="scan_and_connect" description="Scan and connect to the nRF Kit" target="devkit">
+        
+        <scan-for description="Scanning for nRF Kit" address="${EXTRA_ADDRESS}" bind-target="devkit" timeout="10000" expected="SUCCESS"/>
+
+        <connect description="Connecting to nRF Kit" timeout="5000" target="devkit" expected="SUCCESS" />
+
+        <discover-services description="Discover services on the connected device" target="devkit" expected="SUCCESS" />
+
+        <assert-service description="Verify that the service is present" uuid="${TARGET_UUID}" target="devkit" />
+
+    </test>
+
+    <run-test ref="scan_and_connect" description="Scan and connect to nRF Kit" />
+
+</test-suite>

--- a/server/adb_ble_connection/test_connect_result.txt
+++ b/server/adb_ble_connection/test_connect_result.txt
@@ -1,0 +1,59 @@
+20-10-2024 20:20:32
+Version: 4.28.1
+Device: SM-S916B, Android version: 14 (UP1A.231005.007.S916BXXS6CXGA)
+
+Starting 'Scan and connect to the nRF Kit' for 'Scan and connect to nRF Kit'
+   Scanning for nRF Kit...
+20:20:32.707 F1:CD:70:40:99:AA -40 0319400302010603030D180B094E6F726469635F485200
+   OK
+   Connecting to nRF Kit...OK
+   Discover services on the connected device...OK
+   Verify that the service is present...OK
+
+nRF Connect Test, 2024-10-20
+Bluetooth connection between Android device and nRF Kit (test_connect.xml)
+A	20:20:32.558	Starting 'Scan and connect to the nRF Kit' for 'Scan and connect to nRF Kit'
+A	20:20:32.565	Scanning for nRF Kit...
+V	20:20:32.574	Starting scan...
+D	20:20:32.583	scanner.startScan(null, LOW_LATENCY, callback)
+V	20:20:32.717	Stopping scanning...
+D	20:20:32.730	scanner.stopScan(callback)
+I	20:20:32.741	Device found: F1:CD:70:40:99:AA
+A	20:20:32.752	Connecting to nRF Kit...
+V	20:20:32.776	Connecting to F1:CD:70:40:99:AA...
+D	20:20:32.776	gatt = device.connectGatt(autoConnect = false, TRANSPORT_LE, preferred PHY = LE 1M)
+D	20:20:33.095	[Callback] Connection state changed with status: 0 and new state: CONNECTED (2)
+I	20:20:33.095	Connected to F1:CD:70:40:99:AA
+A	20:20:33.107	Discover services on the connected device...
+V	20:20:33.116	Discovering services...
+D	20:20:33.116	gatt.discoverServices()
+D	20:20:33.268	[Callback] Services discovered with status: 0
+I	20:20:33.268	Services discovered
+V	20:20:33.278	Generic Attribute (0x1801)
+- Service Changed [I] (0x2A05)
+   Client Characteristic Configuration (0x2902)
+- Client Supported Features [R W] (0x2B29)
+- Database Hash [R] (0x2B2A)
+Generic Access (0x1800)
+- Device Name [R] (0x2A00)
+- Appearance [R] (0x2A01)
+- Peripheral Preferred Connection Parameters [R] (0x2A04)
+Heart Rate (0x180D)
+- Heart Rate Measurement [N] (0x2A37)
+   Client Characteristic Configuration (0x2902)
+- Body Sensor Location [R] (0x2A38)
+- Heart Rate Control Point [W] (0x2A39)
+D	20:20:33.278	gatt.setCharacteristicNotification(00002a05-0000-1000-8000-00805f9b34fb, true)
+D	20:20:33.279	gatt.setCharacteristicNotification(00002a37-0000-1000-8000-00805f9b34fb, true)
+A	20:20:33.282	Verify that the service is present...
+V	20:20:33.290	Reading services...
+I	20:20:33.290	Service (uuid=0000180D-0000-1000-8000-00805f9b34fb, instance-id=0) found
+V	20:20:33.308	Cleaning up...
+I	20:20:33.800	PHY updated (TX: LE 2M, RX: LE 2M)
+V	20:20:35.320	Disconnecting...
+D	20:20:35.320	gatt.disconnect()
+D	20:20:35.343	[Callback] Connection state changed with status: 0 and new state: DISCONNECTED (0)
+I	20:20:35.343	Disconnected
+D	20:20:35.344	gatt.close()
+D	20:20:35.355	wait(200)
+A	20:20:35.560	'Scan and connect to nRF Kit' completed


### PR DESCRIPTION
- Added test that asserts connection between android device and bluetooth device
- Assumes some service with bluetooth capabilities are preloaded on device

To test run the adb_ble_conn_utils.py file (remember to modify values for android_device_id, target_uuid, and extra_address)
 