### PR TITLE
126 test runner connection test

### DIFF
--- a/server/server_comm/test_runner/views.py
+++ b/server/server_comm/test_runner/views.py
@@ -35,7 +35,7 @@ class RunTestFlow(APIView):
                 "error": None,
             }
             try:
-                res = self.test_setup(flow_id)
+                res = self.check_device_connections(flow_id)
                 if res['status'] != 'success':
                     flow_result["status"] = "failed"
                     flow_result["error"] = res["message"]
@@ -97,17 +97,6 @@ class RunTestFlow(APIView):
             "status": "error",
             "message": "Failed to check device connections",
         }
-
-    def test_setup(self, flow_id):
-        """
-        Set up and assert device connections for the test flow.
-        """
-        #   TODO comment back in when this API is fixed
-        # self.check_device_connections(flow_id)
-
-        # TODO Connect android device(s) in command nodes to nrf kit (LIL-90)
-
-        # TODO Assert that connection is setup (LIL-90)
 
     def run_node(self, node):
         """

--- a/server/server_comm/test_runner/views.py
+++ b/server/server_comm/test_runner/views.py
@@ -26,9 +26,8 @@ class RunTestFlow(APIView):
 
         results = []
 
-        self.test_setup(flow_id)
-
         for flow in test_flows:
+            flow_id = flow.id
             flow_result = {
                 "flow_name": flow.name,
                 "nodes_executed": [],
@@ -36,6 +35,13 @@ class RunTestFlow(APIView):
                 "error": None,
             }
             try:
+                res = self.test_setup(flow_id)
+                if res['status'] != 'success':
+                    flow_result["status"] = "failed"
+                    flow_result["error"] = res["message"]
+                    results.append(flow_result)
+                    break
+
                 flow_parser = FlowParser(flow)
                 execution_order = flow_parser.get_execution_order()
 
@@ -48,6 +54,7 @@ class RunTestFlow(APIView):
                         if result["status"] == "failed":
                             flow_result["status"] = "failed"
                             flow_result["error"] = result["error"]
+                            results.append(flow_result)
                             break
 
             except Exception as e:


### PR DESCRIPTION
- Run connection test for all flows instead of just one if flow_id provided
- Return failure if not connected
- Add failure responses before breaking
- Removed wrapper test_setup as it just calls upon check_device_conncetions anyway, the connecting + checking is the same so it would be a function with 1 line of code just calling another

Please check that this makes sense, and that every possible error is returned