### PR TITLE
140 adb uart log websocket

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -67,6 +67,7 @@ PyQt6-sip==13.6.0
 PyQt6-WebEngine==6.7.0
 PyQt6-WebEngine-Qt6==6.7.0
 pyserial==3.5
+pyserial-asyncio==0.6
 PySocks==1.7.1
 pytest==8.3.3
 pytest-asyncio==0.24.0

--- a/server/server.py
+++ b/server/server.py
@@ -1,29 +1,164 @@
 import asyncio
 import json
+import os
+import sys
 
+import django
+import serial_asyncio
 import websockets
+from asgiref.sync import sync_to_async
+from serial.tools import list_ports
+
+# set current dir to same as django so imports are possible
+current_dir = os.path.dirname(os.path.abspath(__file__))
+server_comm_dir = os.path.join(current_dir, "server_comm")
+os.chdir(server_comm_dir)
+sys.path.append(server_comm_dir)
+
+# set up django environment
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server_comm.settings')
+django.setup()
+
+# import view from django
+from device_connection.views import FlowDeviceConnectionView  # type: ignore
 
 
-# Load mock logs
-def load_logs():
-    with open("./assets/mock_data.json", "r") as file:
-        logs = json.load(file)
-    return logs["logItems"]
+async def adb_log_stream(adb_device_id):
+    process = await asyncio.create_subprocess_exec(
+        "adb",
+        "-s",
+        adb_device_id,
+        "logcat",
+        stdout=asyncio.subprocess.PIPE,
+    )
+
+    try:
+        while True:
+            log_line = await process.stdout.readline()
+            if not log_line:
+                await asyncio.sleep(0.1)
+                continue
+            yield log_line.decode('utf-8').strip()
+
+    except asyncio.CancelledError:
+        print(f"ADB log stream for {adb_device_id} was closed")
+
+    except Exception as e:
+        print(
+            f"Error occurred while logging adb device {adb_device_id}: {str(e)}"
+        )
+
+    finally:
+        process.terminate()
+        await process.wait()
 
 
-async def log(websocket):
-    print("Server connected")
+async def uart_log_stream(serial_number):
+    def get_device_port(serial_number: str):
+        ports = list_ports.comports()
+        for port in ports:
+            if port.serial_number == serial_number:
+                return port.device
+        return None
 
-    logs = load_logs()
+    device_port = get_device_port(serial_number)
+    if not device_port:
+        print(f"No port detected for serial number {serial_number}")
+        return
 
-    for log_entry in logs:
-        log_message = json.dumps(log_entry)
-        await websocket.send(log_message)
-        print(f"Server sent log {log_entry['id']}")
+    reader, _ = await serial_asyncio.open_serial_connection(url=device_port)
+
+    try:
+        while True:
+            line = await reader.readline()
+            yield line
+
+    except asyncio.CancelledError:
+        print(f"UART log stream for {serial_number} was closed")
+
+    except Exception as e:
+        print(
+            f"Error occurred while logging UART device {serial_number}: {str(e)}"
+        )
+
+    finally:
+        reader.close()
+
+
+async def stream_device_log(
+    websocket, device_id, device_name, conn_type, conn_id, log_id
+):
+    match conn_type:
+        case "adb":
+            log_stream = adb_log_stream
+        case "uart":
+            log_stream = uart_log_stream
+        case _:
+            print(f"Unsupported connection type: {conn_type}")
+            return
+
+    try:
+        async for line in log_stream(conn_id):
+            log_entry = {
+                "id": log_id,
+                "name": f"{device_name} - {conn_type}",
+                "log": (
+                    line.decode("utf-8").strip()
+                    if isinstance(line, bytes)
+                    else line
+                ),
+            }
+            log_message = json.dumps(log_entry)
+            await websocket.send(log_message)
+
+    except websockets.ConnectionClosed:
+        print(f"Connection closed for {device_name} (ID: {device_id})")
+
+
+async def log_all(websocket, path):
+    # parse flow_id from path
+    flow_id = path.split("/")[-1]
+    print(f"Server connected, logging for flow {flow_id}")
+
+    flow_view = FlowDeviceConnectionView()
+    devices_conn, _, devices_name = await sync_to_async(
+        flow_view.parse_devices
+    )(flow_id)
+
+    # log counter to give ids to each log
+    log_ids = {}
+    current_log_id = 1
+    for device_id in devices_name:
+        log_ids.setdefault(device_id, {})
+        for conn_type in devices_conn[device_id].keys():
+            log_ids[device_id].setdefault(conn_type, current_log_id)
+            current_log_id += 1
+
+    # one task per device per connection type
+    tasks = []
+    for device_id in devices_name:
+        device_name: str = devices_name[device_id]
+        device_conn: list = devices_conn[device_id]
+
+        for conn_type, conn_id in device_conn.items():
+            log_id = log_ids[device_id][conn_type]
+            tasks.append(
+                stream_device_log(
+                    websocket,
+                    device_id,
+                    device_name,
+                    conn_type,
+                    conn_id,
+                    log_id,
+                )
+            )
+
+    await asyncio.gather(*tasks)
 
 
 async def main():
-    async with websockets.serve(log, "localhost", 8765):
+    async with websockets.serve(log_all, "localhost", 8765):
+        print("Websocket startet running on port 8765")
         await asyncio.Future()  # run forever
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -132,9 +132,16 @@ async def stream_device_log(
 async def log_all(
     websocket: websockets.WebSocketServerProtocol, path: str
 ) -> None:
+    await websocket.send(json.dumps({"message": "Connected to websocket!"}))
+
     # parse flow_id from path
-    flow_id = path.split("/")[-1]
-    print(f"Server connected, logging for flow {flow_id}")
+    flow_id_str = path.split("/")[-1]
+    if not flow_id_str.isdigit():
+        await websocket.send(
+            json.dumps({"error": "Missing or invalid flow ID"})
+        )
+        return
+    flow_id: int = int(flow_id_str)
 
     flow_view = views.FlowDeviceConnectionView()
     devices_conn, _, devices_name = await sync_to_async(

--- a/server/server_comm/device_connection/views.py
+++ b/server/server_comm/device_connection/views.py
@@ -259,7 +259,7 @@ class nRFConnectionView(View):
 
 
 class FlowDeviceConnectionView(View):
-    def parse_devices(self, flow_id: str):
+    def parse_devices(self, flow_id: int):
         flow = Flow.objects.get(id=flow_id)
         devices_conn: dict[str, dict] = {}
         devices_comm: dict[str, dict] = {}
@@ -297,7 +297,7 @@ class FlowDeviceConnectionView(View):
 
         return devices_conn, devices_comm, devices_name
 
-    def connect_devices(self, flow_id: str):
+    def connect_devices(self, flow_id: int):
         devices_conn, devices_comm, _ = self.parse_devices(flow_id)
         responses = []
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -28,3 +28,4 @@ def start_server():
     poll_server()
     yield
     process.terminate()
+    process.wait()

--- a/server/tests/test_connection.py
+++ b/server/tests/test_connection.py
@@ -8,8 +8,17 @@ from conftest import WEBSOCKET_URL
 @pytest.mark.asyncio
 async def test_load_logs(start_server):
     async with websockets.connect(WEBSOCKET_URL) as websocket:
-        log_message = await websocket.recv()
-        log_data = json.loads(log_message)
+        log_msg = await websocket.recv()
+        log_data = json.loads(log_msg)['message']
+        assert (
+            log_data == "Connected to websocket!"
+        ), "Could not connect to server"
 
-        assert "id" in log_data, "Log entry should contain an 'id'"
-        print(f"Received log with id: {log_data['id']}")
+
+@pytest.mark.asyncio
+async def test_invalid_flow_id(start_server):
+    async with websockets.connect(WEBSOCKET_URL) as websocket:
+        _ = await websocket.recv()
+        flow_error_msg = await websocket.recv()
+        flow_error_data = json.loads(flow_error_msg)['error']
+        assert flow_error_data == "Missing or invalid flow ID"


### PR DESCRIPTION
* Fixed error in device_connection where connection types without a corresponding id would crash the server (because it would try to look it up in the dict and fail)
* Added uart logging to websockets
* Added adb logcat logging to websockets

2 hrs were spent debugging the goddamn imports because the server.py file is outside the django project but wants to use django-project stuff (we need to know the devices in the flow). This would be solved by having websockets in an app there. Just writing this down so if you look at the weird imports and think "why do we set the directory there? what is this django.setup()?" that is for that.